### PR TITLE
Corrige instrução para reset do Console

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -32,7 +32,7 @@ namespace Contagem_Regressiva
             Console.WriteLine("--------");
            
             Console.ReadKey();
-            Console.ForegroundColor= ConsoleColor.White;
+            Console.ResetColor();
         }
     }
 }


### PR DESCRIPTION
A utilização de Console.ResetColor(); é a melhor prática, ao invés de atribuir a cor branca à fonte do Console.
Com o ResetColor(), você garante que a cor padrão seja reestabelecida, uma vez que a cor padrão do console do usuário pode ser o fundo branco com a fonte preta.